### PR TITLE
Fix metrics for unsynced node

### DIFF
--- a/pkg/rpc/errors.go
+++ b/pkg/rpc/errors.go
@@ -29,7 +29,7 @@ const (
 
 type (
 	NodeUnhealthyErrorData struct {
-		NumSlotsBehind int64 `json:"numSlotsBehind"`
+		NumSlotsBehind *int64 `json:"numSlotsBehind"`
 	}
 )
 


### PR DESCRIPTION
Changed `NumSlotsBehind` to a pointer to differentiate nil values and added error unpacking logic for better handling of unhealthy node data. Improved logging to provide clearer information on node health status and removed redundant error wrapping.